### PR TITLE
Add loading="lazy" attribute support

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "bellroy/elm-embed-youtube",
     "summary": "A wrapper around the Youtube iFrame Api",
     "license": "BSD-3-Clause",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "exposed-modules": [
         "Embed.Youtube",
         "Embed.Youtube.Attributes",

--- a/src/Embed/Youtube/Attributes.elm
+++ b/src/Embed/Youtube/Attributes.elm
@@ -1,5 +1,6 @@
 module Embed.Youtube.Attributes exposing
     ( width, height
+    , lazyLoad
     , autoplay, loop, start, end, mute
     , colorRed, colorWhite, modestBranding, playsInline, hideControls, disableKeyboard, disableFullscreen, disableVideoAnnotations
     , language
@@ -12,6 +13,11 @@ module Embed.Youtube.Attributes exposing
 # Sizing
 
 @docs width, height
+
+
+# iframe HTML Attributes
+
+@docs lazyLoad
 
 
 # Playback
@@ -54,6 +60,17 @@ width =
 height : Int -> Attribute
 height =
     Height
+
+
+
+-- iframe HTML Attributes
+
+
+{-| Set the loading attribute of the iframe to `lazy`
+-}
+lazyLoad : Attribute
+lazyLoad =
+    LazyLoad
 
 
 

--- a/src/Embed/Youtube/Internal/Attribute.elm
+++ b/src/Embed/Youtube/Internal/Attribute.elm
@@ -7,6 +7,7 @@ module Embed.Youtube.Internal.Attribute exposing (Attribute(..))
 type Attribute
     = Width Int
     | Height Int
+    | LazyLoad
     | Autoplay
     | Loop
     | Start Int

--- a/src/Embed/Youtube/Internal/View.elm
+++ b/src/Embed/Youtube/Internal/View.elm
@@ -2,7 +2,7 @@ module Embed.Youtube.Internal.View exposing (toIframe, toYoutubeUrl)
 
 import Embed.Youtube.Internal.Attribute as YoutubeAttribute exposing (Attribute(..))
 import Embed.Youtube.Internal.Youtube exposing (Youtube(..), YoutubeVideoId(..))
-import Html as Html exposing (Html)
+import Html exposing (Html)
 import Html.Attributes as HtmlA
 import Url exposing (Protocol(..), Url)
 import Url.Builder as UrlBuilder exposing (QueryParameter)
@@ -78,6 +78,9 @@ toHtmlAttribute attribute =
         Height a ->
             Just <| HtmlA.height a
 
+        LazyLoad ->
+            Just <| HtmlA.attribute "loading" "lazy"
+
         _ ->
             Nothing
 
@@ -92,6 +95,9 @@ toQueryParameters_ (YoutubeVideoId stringYoutubeVideoId) attribute =
             []
 
         Height _ ->
+            []
+
+        LazyLoad ->
             []
 
         Autoplay ->


### PR DESCRIPTION
Safari 16.4 now supports native lazy loading of iframes. Seems like a good time to add first class support for it here as well.